### PR TITLE
Fix/pruned edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Wrapper for btcpayserver
+# BTCPay Server for StartOS
 
-[BTCPay Server](https://btcpayserver.org/) is a self-hosted, open-source cryptocurrency payment processor. It's secure, private, censorship-resistant and free. This repository creates the `s9pk` package that is installed to run `btcpayserver` on [embassyOS](https://github.com/Start9Labs/embassy-os/).
+[BTCPay Server](https://btcpayserver.org/) is a self-hosted, open-source cryptocurrency payment processor. It's secure, private, censorship-resistant and free. This repository creates the `s9pk` package that is installed to run `btcpayserver` on [StartOS](https://github.com/Start9Labs/embassy-os/).
 
 ## Dependencies
 
@@ -32,16 +32,16 @@ After setting up your environment, build the `btcpayserver` package by running:
 make
 ```
 
-## Installing (on embassyOS)
+## Installing (on StartOS)
 
 Run the following commands to install:
 
-> :information_source: Change embassy-server-name.local to your Embassy address
+> :information_source: Change adjective-noun.local to your Start9 Server LAN address
 
 ```
 embassy-cli auth login
-# Enter your embassy password
-embassy-cli --host https://embassy-server-name.local package install btcpayserver.s9pk
+# Enter your server's master password
+embassy-cli --host https://adjective-noun.local package install btcpayserver.s9pk
 ```
 
 If you already have your `embassy-cli` config file setup with a default `host`,
@@ -52,10 +52,10 @@ make install
 ```
 
 > **Tip:** You can also install the btcpayserver.s9pk using **Sideload Service** under
-the **Embassy > Settings** section.
+the **System > Settings** section.
 
 ### Verify Install
 
-Go to your Embassy Services page, select **BTCPay Server**, configure and start the service. Then, verify its interfaces are accessible.
+Go to your Start9 Server Services page, select **BTCPay Server**, configure and start the service. Then, verify its interfaces are accessible.
 
 **Done!** 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 id: btcpayserver
 title: BTCPay Server
-version: 1.10.3
+version: 1.10.3.1
 release-notes: |
   * Updates to the upstream release of [v1.10.3](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.10.3)
   * Removes deprecated optional dependency of BTC RPC Proxy

--- a/scripts/procedures/dependencies.ts
+++ b/scripts/procedures/dependencies.ts
@@ -35,6 +35,19 @@ const matchBitcoindConfig = shape({
   }),
 });
 
+const matchOldBitcoindConfig = shape({
+  rpc: shape({
+    advanced: shape({
+      serialversion: matches.any
+    }),
+  }),
+  advanced: shape({
+    pruning: shape({
+      mode: string,
+    }),
+  }),
+})
+
 
 const bitcoindChecks: Array<Check> = [
   {
@@ -69,6 +82,20 @@ const bitcoindChecks: Array<Check> = [
         return
       }
       config.advanced.peers.listen = true;
+    },
+  },
+  {
+    currentError(config) {
+      if (matchOldBitcoindConfig.test(config) && config.advanced.pruning.mode !== "disabled") {
+        return 'Pruning must be disabled to use with <= 24.0.1 of Bitcoin Core. To use with a pruned node, update Bitcoin Core to >= 25.0.0~2.';
+      }
+      return;
+    },
+    fix(config) {
+      if (!matchOldBitcoindConfig.test(config)) {
+        return
+      }
+      config.advanced.pruning.mode = "disabled"
     },
   }
 ];

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -48,6 +48,6 @@ export const migration: T.ExpectedExports.migration = async (effects, version, .
           ),
         },
       },
-      "1.10.3",
+      "1.10.3.1",
     )(effects, version, ...args)
 }


### PR DESCRIPTION
adding logic to check the shape of the bitcoin config in the case of a pruned node. in order to ensure all functionality persists for wallet imports that may have history in blocks created outside of the nodes pruned range, ensure the user updates their node to full archival. can alternatively update to bitcoin v25.0.0.2.

also edit readme copy.